### PR TITLE
Updated the dependencies to make powar work with Deno 2.0

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
 export * as path from "jsr:@std/path@1.0.6";
 export * as fs from "jsr:@std/fs@1.0.4";
 export * as io from "jsr:@std/io@0.225.0";
-export * as cliffy from "jsr:@cliffy/command@1.0.0-rc.7";
+export * as cliffy from "jsr:@cliffy/command@1.0.0-rc.5";

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export * as path from "https://deno.land/std@0.197.0/path/mod.ts";
-export * as fs from "https://deno.land/std@0.197.0/fs/mod.ts";
-export * as io from "https://deno.land/std@0.197.0/io/mod.ts";
-export * as cliffy from "https://deno.land/x/cliffy@v1.0.0-rc.3/command/mod.ts";
+export * as path from "jsr:@std/path@1.0.6";
+export * as fs from "jsr:@std/fs@1.0.4";
+export * as io from "jsr:@std/io@0.225.0";
+export * as cliffy from "jsr:@cliffy/command@1.0.0-rc.7";

--- a/powar_init.ts
+++ b/powar_init.ts
@@ -14,7 +14,7 @@ async function init() {
       "The path to initialise the project in.",
       { required: true }
     )
-    .action(async (args) => {
+    .action(async (args: { path: string; }) => {
       const log = makeLogger();
 
       // Copy the example folder to the given path.

--- a/powar_init.ts
+++ b/powar_init.ts
@@ -14,7 +14,7 @@ async function init() {
       "The path to initialise the project in.",
       { required: true }
     )
-    .action(async (args: { path: string; }) => {
+    .action(async (args) => {
       const log = makeLogger();
 
       // Copy the example folder to the given path.


### PR DESCRIPTION
One of the dependencies (presumably cliffy) causes an error due to deprecation.

```ts
error: Import assertions are deprecated. Use `with` keyword, instead of 'assert' keyword.

import data from "./_data.json" assert { type: "json" };

  at https://deno.land/std@0.196.0/console/unicode_width.ts:4:1
```

Updating the dependencies to the most recent version seems to fix this issue.